### PR TITLE
deprecate gluejar.com emails

### DIFF
--- a/api/onix.py
+++ b/api/onix.py
@@ -40,7 +40,7 @@ def header(facet=None):
     header_node = etree.Element("Header")	
     sender_node = etree.Element("Sender")	
     sender_node.append(text_node("SenderName", "unglue.it"))
-    sender_node.append(text_node("EmailAddress", "support@gluejar.com"))
+    sender_node.append(text_node("EmailAddress", "support@ebookfoundation.org"))
     header_node.append(sender_node)
     header_node.append(text_node("SentDateTime", pytz.utc.localize(datetime.datetime.utcnow()).strftime('%Y%m%dT%H%M%SZ')))
     header_node.append(text_node("MessageNote", facet.title if facet else "Unglue.it Editions"))

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -186,7 +186,7 @@ def notify_claim(sender, created, instance, **kwargs):
     if 'example.org' in instance.user.email or hasattr(instance, 'dont_notify'):
         return
     try:
-        (rights, new_rights) = User.objects.get_or_create(email='rights@gluejar.com', defaults={'username':'RightsatUnglueit'})
+        (rights, new_rights) = User.objects.get_or_create(email='rights@ebookfoundation.org', defaults={'username':'RightsatUnglueit'})
     except:
         rights = None
     if instance.user == instance.rights_holder.owner:

--- a/core/search.py
+++ b/core/search.py
@@ -6,7 +6,7 @@ import regluit.core.isbn
 from django.conf import settings
 
 def gluejar_search(q, user_ip='69.243.24.29', page=1):
-    """normalizes results from the google books search suitable for gluejar
+    """normalizes results from the google books search suitable for unglue.it
     """
     results = []
     search_result=googlebooks_search(q, user_ip, page)

--- a/deploy/just.conf
+++ b/deploy/just.conf
@@ -4,7 +4,7 @@ WSGISocketPrefix /opt/regluit
 <VirtualHost *:80>
 
 ServerName just.unglue.it
-ServerAdmin info@gluejar.com
+ServerAdmin support@ebookfoundation.org
 
 Redirect permanent / https://just.unglue.it/
 

--- a/deploy/localvm.conf
+++ b/deploy/localvm.conf
@@ -4,7 +4,7 @@ WSGISocketPrefix /opt/regluit
 <VirtualHost *:80>
 
 ServerName localvm
-ServerAdmin info@gluejar.com
+ServerAdmin support@ebookfoundation.org
 
 Redirect permanent / https://192.168.33.10.xip.io:443/
 

--- a/deploy/please.conf
+++ b/deploy/please.conf
@@ -4,7 +4,7 @@ WSGISocketPrefix /opt/regluit
 <VirtualHost *:80>
 
 ServerName please.unglueit.com
-ServerAdmin info@gluejar.com
+ServerAdmin support@ebookfoundation.org
 
 RewriteEngine On
 RewriteRule ^/$ https://please.unglue.it/ [R=301]

--- a/deploy/prod.conf
+++ b/deploy/prod.conf
@@ -3,7 +3,7 @@ WSGISocketPrefix /opt/regluit
 
 <VirtualHost _default_:80>
 
-ServerAdmin info@gluejar.com
+ServerAdmin support@ebookfoundation.org
 
 Redirect permanent / https://unglue.it/
 

--- a/frontend/templates/about_smashwords.html
+++ b/frontend/templates/about_smashwords.html
@@ -8,7 +8,7 @@
 
 <ul>
     <li>Make sure your book meets Smashwords' <a href="http://www.smashwords.com/distribution">standards for inclusion</a> in their Premium Catalog.  Consult the <a href="http://www.smashwords.com/books/view/52">Smashwords Style Guide</a> for details.</li>
-    <li>Contact <a href="mailto:rights@gluejar.com">rights@gluejar.com</a> about signing a Platform Services Agreement with Unglue.it, and follow the instructions on the <a href="/rightsholders/">rights holder tools page</a> to claim your book, develop a publicity strategy, and start a campaign.</li>
+    <li>Contact <a href="mailto:rights@ebookfoundation.org">rights@ebookfoundation.org</a> about signing a Platform Services Agreement with Unglue.it, and follow the instructions on the <a href="/rightsholders/">rights holder tools page</a> to claim your book, develop a publicity strategy, and start a campaign.</li>
 </ul>
 
 <h2>Why Unglue Your Book?</h2>

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -162,9 +162,9 @@
         <span>Contact</span>
         <ul>
             <li>General inquiries</li>
-            <li><a href="mailto:faq@gluejar.com">faq@gluejar.com</a></li>
+            <li><a href="mailto:info@ebookfoundation.org">info@ebookfoundation.org</a></li>
             <li>Rights Holders</li>
-            <li><a href="mailto:rights@gluejar.com">rights@gluejar.com</a></li>
+            <li><a href="mailto:rights@ebookfoundation.org">rights@ebookfoundation.org</a></li>
         </ul>
     </div>
   </div>

--- a/frontend/templates/claim.html
+++ b/frontend/templates/claim.html
@@ -40,6 +40,6 @@
 {% endif %}
 <h3> Interfering claims  </h3>
 <p>
-When a rights holder claims a work in unglue.it, they warrant and represent that they have sufficient rights to release a Creative Commons edition of that work. Unfortunately, mistakes can occur, especially for older works with unclear contracts and hard-to-find rights holders. For that reason, rights holders also agree to respond promptly to rights inquiries, and unglue.it reserves the right to suspend campaigns when disputes over rights arise. If you have a question about claims for this work, please contact rights@gluejar.com
+When a rights holder claims a work in unglue.it, they warrant and represent that they have sufficient rights to release a Creative Commons edition of that work. Unfortunately, mistakes can occur, especially for older works with unclear contracts and hard-to-find rights holders. For that reason, rights holders also agree to respond promptly to rights inquiries, and unglue.it reserves the right to suspend campaigns when disputes over rights arise. If you have a question about claims for this work, please contact rights@ebookfoundation.org
 </p>
 {% endblock %}

--- a/frontend/templates/faq.html
+++ b/frontend/templates/faq.html
@@ -98,15 +98,15 @@ Lots of reasons:
 <dd>A rights holder is the person (or entity) that holds the legal right to copy, distribute, or sell a book in some way.  There may be one entity with all the rights to a work, or the rights may be split up among different entities: for example, one who publishes the print edition in the United States, another who publishes the print edition in the EU, another who holds electronic rights, et cetera.  For ungluing purposes, the rights holder is the entity who has uncontested worldwide commercial rights to a work.<br /><br />
 If you have written a book and not signed any contracts about it, you hold all the rights.  If you have signed a contract with a publisher to produce, distribute, publish, or sell your work in a particular format or a particular territory, whether or not you still hold rights depends on the language of that contract.  We encourage you to check your contracts.  It may be in your interest to explore launching an Unglue.it campaign jointly with your publisher.<br /><br />
 If you haven't written a book but you have had business or family relationships with someone who has, it's possible that you are a rights holder (for instance, you may have inherited rights from the author's estate, or your company may have acquired them during a merger).  Again, this all depends on the specific language of your contracts.  We encourage you to read them closely.  Unglue.it cannot provide legal advice.<br /><br />
-If you believe you are a rights holder and would like to your works to be unglued, please contact us at <a href="mailto:rights@gluejar.com">rights@gluejar.com</a>.</dd>
+If you believe you are a rights holder and would like to your works to be unglued, please contact us at <a href="mailto:rights@ebookfoundation.org">rights@ebookfoundation.org</a>.</dd>
 
 <dt>I know a book that should be unglued.</dt>
 
-<dd>Great! Find it in our database (using the search box above) and add it to your favorites, so we know it should be on our list, too.  And encourage your friends to add it to their favorites.  The more people that fave a book on Unglue.it, the more attractive it will be for authors and publishers to launch an ungluing campaign.  You can also contact us at <a href="mailto:rights@gluejar.com">rights@gluejar.com</a>.</dd>
+<dd>Great! Find it in our database (using the search box above) and add it to your favorites, so we know it should be on our list, too.  And encourage your friends to add it to their favorites.  The more people that fave a book on Unglue.it, the more attractive it will be for authors and publishers to launch an ungluing campaign.  You can also contact us at <a href="mailto:rights@ebookfoundation.org">rights@ebookfoundation.org</a>.</dd>
 
 <dt>I know a book that should be unglued, and I own the commercial rights.</dt>
 
-<dd>Fabulous!  Please refer to the <a href="/faq/rightsholders/">FAQ for Rights Holders</a> and then contact us at <a href="mailto:rights@gluejar.com">rights@gluejar.com</a>.  Let's talk.</dd>
+<dd>Fabulous!  Please refer to the <a href="/faq/rightsholders/">FAQ for Rights Holders</a> and then contact us at <a href="mailto:rights@ebookfoundation.org">rights@ebookfoundation.org</a>.  Let's talk.</dd>
 
 <dt>Is there a widget that can be put on my own site to share my favorite books or campaigns?</dt>
 
@@ -158,7 +158,7 @@ If you receive our newsletter, there's a link at the bottom of every message to 
 <dl>
 <dt>How can I contact Unglue.it?</dt>
 
-<dd>For support requests, <a href="{% url 'feedback' %}?page=need+support">use our feedback form</a>.  For general inquiries, use our Ask Questions Frequently account, <a href="mailto:aqf@gluejar.com">aqf@gluejar.com</a>.  For rights inquiries, <a href="mailto:rights@gluejar.com">rights@gluejar.com</a>.  Media requests, <a href="mailto:press@gluejar.com">press@gluejar.com</a></dd>
+<dd>For support requests, <a href="{% url 'feedback' %}?page=need+support">use our feedback form</a>.  For general or media inquiries, mail us at <a href="mailto:info@ebookfoundation.org">info@ebookfoundation.org</a>.  For rights inquiries, <a href="mailto:rights@ebookfoundation.org">rights@ebookfoundation.org</a>.  </dd>
 
 <dt>Who is Unglue.it?</dt>
 
@@ -166,7 +166,7 @@ If you receive our newsletter, there's a link at the bottom of every message to 
 
 <dt>Are you a non-profit company?</dt>
 
-<dd>Yes. Unglue.it is a program of the Free Ebook Foundation, which is a not-for-profit corporation.  We work with both non-profit and commercial partners.</dd>
+<dd>Yes. Unglue.it is a program of the Free Ebook Foundation, which is a 501(c)3 not-for-profit corporation.  We work with both non-profit and commercial partners.</dd>
 
 <dt>Why does Unglue.it exist?</dt>
 
@@ -368,13 +368,13 @@ Unglue.it signs agreements assuring the copyright status of every work we unglue
 <dd>To start a campaign, you need to be a verified rights holder who has signed a Platform Services Agreement with us.  </dd>
 <dt>What do I need to do to become an authorized Rights Holder on Unglue.it?</dt>
 
-<dd>Contact our Rights Holder Relations team, <a href="mailto:rights@gluejar.com">rights@gluejar.com</a>, to discuss signing our <a href="https://www.docracy.com/1mud3ve9w8/unglue-it-non-exclusive-platform-services-agreement">Platform Services Agreement (PSA)</a>, setting a revenue goal, and running a campaign on Unglue.it to release your book under a <a href="http://creativecommons.org">Creative Commons</a> license, or to raise money for a book you've already released under such a license.</dd>
+<dd>Contact our Rights Holder Relations team, <a href="mailto:rights@ebookfoundation.org">rights@ebookfoundation.org</a>, to discuss signing our <a href="https://www.docracy.com/1mud3ve9w8/unglue-it-non-exclusive-platform-services-agreement">Platform Services Agreement (PSA)</a>, setting a revenue goal, and running a campaign on Unglue.it to release your book under a <a href="http://creativecommons.org">Creative Commons</a> license, or to raise money for a book you've already released under such a license.</dd>
 
 <dt>I haven't signed an agreement, but my books are listed on Unglue.it. What's going on?</dt>
 <dd>If your book is listed on Unglue.it, it's because an unglue.it user has indicated some interested in the book. Perhaps your book has been added to a user's favorites list. Users can also use the site to post links to Creative Commons licensed or public domain books. Unglue.it works with non-profit sites such as Internet Archive to improve their coverage and preservation of Creative Commons licensed books.
 </dd>
 <dt>I didn't give you permission to offer my CC-licensed book for download. Why is it there?</dt>
-<dd>When we don't have an agreement with a rights-holder, our download links lead to sites such as Internet Archive, Project Gutenberg, or Google Books that facilitate this linking and free use of the works by our users. We strive to keep our information accurate, so if the license we report is inaccurate, please <a href="mailto:rights@gluejar.com?subject=corrections">let us know</a> immediately. If for some reason you don't want us to provide download links, let us know using the "feedback" tab next to your book's page and we'll make a notation to that effect in our metadata. We may require evidence that you are authorized to act for the rights holders of the book.
+<dd>When we don't have an agreement with a rights-holder, our download links lead to sites such as Internet Archive, Project Gutenberg, or Google Books that facilitate this linking and free use of the works by our users. We strive to keep our information accurate, so if the license we report is inaccurate, please <a href="mailto:rights@ebookfoundation.org?subject=corrections">let us know</a> immediately. If for some reason you don't want us to provide download links, let us know using the "feedback" tab next to your book's page and we'll make a notation to that effect in our metadata. We may require evidence that you are authorized to act for the rights holders of the book.
 </dd>
 
 <dt>Do I need to know the exact titles I might want to unglue before I sign the Platform Services Agreement?</dt>
@@ -400,7 +400,7 @@ Unglue.it signs agreements assuring the copyright status of every work we unglue
 	    <li>Your metadata should have title, authors, language, description.</li>
 	    <li>If you have a lot of books to enter, <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">contact us</a> to load ONIX or CSV files for you.</li>
 	</ul>
-<br /><br />If you expect to see a "Claim" button and do not, either we do not have a PSA from you yet, or we have not yet verified and filed it.  Please contact us at <a href="mailto:rights@gluejar.com">rights@gluejar.com</a>.</dd>
+<br /><br />If you expect to see a "Claim" button and do not, either we do not have a PSA from you yet, or we have not yet verified and filed it.  Please contact us at <a href="mailto:rights@ebookfoundation.org">rights@ebookfoundation.org</a>.</dd>
 
 <dt>Why should I claim my works?</dt>
 
@@ -418,7 +418,7 @@ If you want to find an interesting campaign and don't have a specific book in mi
 <dl>
 <dt>What do I need to create a campaign?</dt>
 
-<dd>First, you need to be an authorized rights holder with a signed Platform Services Agreement on file.  Please contact <a href="mailto:rights@gluejar.com">rights@gluejar.com</a> to start this process.  Once we have your PSA on file, you'll be able to claim your works and you'll have access to tools for launching and monitoring campaigns.  We'll be happy to walk you through the process personally.</dd>
+<dd>First, you need to be an authorized rights holder with a signed Platform Services Agreement on file.  Please contact <a href="mailto:rights@ebookfoundation.org">rights@ebookfoundation.org</a> to start this process.  Once we have your PSA on file, you'll be able to claim your works and you'll have access to tools for launching and monitoring campaigns.  We'll be happy to walk you through the process personally.</dd>
 
 <dt>Can I unglue only one of my books?  Can I unglue all of them?</dt>
 

--- a/frontend/templates/feedback.html
+++ b/frontend/templates/feedback.html
@@ -6,7 +6,7 @@
 
 	<p>Love something? Hate something? Found something broken or confusing?  Thanks for telling us!</p>
 
-	To: support@gluejar.com<br /><br />
+	To: support@ebookfoundation.org<br /><br />
     <form method="POST" action="{% url 'feedback' %}">
         {% csrf_token %}
 		{{ form.sender.errors }}
@@ -29,5 +29,5 @@
        <input type="submit" value="Submit" />    
     </form>
     
-    <p>If for some reason this form doesn't work, you can send email to unglue.it support at <a href="mailto:support@gluejar.com">support@gluejar.com</a>.</p>
+    <p>If for some reason this form doesn't work, you can send email to unglue.it support at <a href="mailto:support@ebookfoundation.org">support@ebookfoundation.org</a>.</p>
 {% endblock %}

--- a/frontend/templates/libraries.html
+++ b/frontend/templates/libraries.html
@@ -60,7 +60,7 @@ The library license gives download access to one library member at a time for 14
 <dt>Support <a href="{% url 'campaign_list' 'ending' %}">our active campaigns</a>.</dt>
 <dd>Ultimately ebooks can't be unglued unless authors and publishers are paid for their work.  Many of our staunchest supporters are librarians.  There are also several libraries which have supported campaigns, including Leddy Library (University of Windsor, Ontario); the University of Alberta library ; and the Z. Smith Reynolds library (Wake Forest University).</dd>
 <dt>Give feedback and ask questions.</dt>
-<dd>Want to know more?  Need help?  Have ideas for how we could improve the site or make it more library-friendly?  Contact us at: <a href="mailto:libraries@gluejar.com">libraries@gluejar.com</a>.</dd>
+<dd>Want to know more?  Need help?  Have ideas for how we could improve the site or make it more library-friendly?  Contact us at: <a href="mailto:info@ebookfoundation.org">info@ebookfoundation.org</a>.</dd>
 </dl>
 </div>
 {% endblock %}

--- a/frontend/templates/ml_status.html
+++ b/frontend/templates/ml_status.html
@@ -5,7 +5,7 @@ You are subscribed to the Unglue.it Newsletter. It comes roughly twice a month. 
 <input type="submit" name="ml_unsubscribe" value="Unsubscribe" />
 </form>
 {% else %}
-You are NOT subscribed to the Unglue.it Newsletter.  It comes roughly twice a month. If you have just become an ungluer, your list invitation should be on its way. Put "gluenews@gluejar.com" in your contact list to make sure you get it.<br />
+You are NOT subscribed to the Unglue.it Newsletter.  It comes roughly twice a month. If you have just become an ungluer, your list invitation should be on its way. Put "unglueit@ebookfoundation.org" in your contact list to make sure you get it.<br />
 <form id="ml_subscribe" action="{% url 'ml_subscribe' %}" method="POST">
 {% csrf_token %}
 <input type="submit" name="ml_subscribe" value="Subscribe" />

--- a/frontend/templates/notification/account_active/full.txt
+++ b/frontend/templates/notification/account_active/full.txt
@@ -1,7 +1,7 @@
 {% load humanize %}
 As you requested, we've updated your account with the payment method you provided.
 
-If you have any questions, we are happy to help. Simply email us at support@gluejar.com.
+If you have any questions, we are happy to help. Simply email us at support@ebookfoundation.org.
         
 {% if user.profile.account %}
 The current card we have on file:

--- a/frontend/templates/notification/account_expired/full.txt
+++ b/frontend/templates/notification/account_expired/full.txt
@@ -3,7 +3,7 @@ We want to let you know that your {{ user.profile.account.card_type }} card endi
 
 When you receive your new card, simply go to https://{{ site.domain }}{% url 'manage_account' %} to enter your card information. Thank you!
 
-If you have any questions, we are happy to help. Simply email us at support@gluejar.com.
+If you have any questions, we are happy to help. Simply email us at support@ebookfoundation.org.
         
 {% if user.profile.account %}
 The current card we have on file:

--- a/frontend/templates/notification/account_expiring/full.txt
+++ b/frontend/templates/notification/account_expiring/full.txt
@@ -3,7 +3,7 @@ We want to give you advance notice that your {{ user.profile.account.card_type }
 
 When you receive your new card, simply go to https://{{ site.domain }}{% url 'manage_account' %} to enter your card information. Thank you!
 
-If you have any questions, we are happy to help. Simply email us at support@gluejar.com.
+If you have any questions, we are happy to help. Simply email us at support@ebookfoundation.org.
         
 {% if user.profile.account %}
 The current card we have on file:

--- a/frontend/templates/notification/pledge_you_have_pledged/full.txt
+++ b/frontend/templates/notification/pledge_you_have_pledged/full.txt
@@ -17,7 +17,7 @@ Or the best idea: talk about it with those you love.  We'll need lots of help fr
 
 If you want to change your pledge, just use the button at https://{{ current_site.domain }}{% url 'work' transaction.campaign.work.id %}
 
-If you have any problems with your pledge, don't hesitate to contact us at support@gluejar.com
+If you have any problems with your pledge, don't hesitate to contact us at support@ebookfoundation.org
 
 Thanks for being part of Unglue.it.
 

--- a/frontend/templates/notification/purchase_notgot_gift/full.txt
+++ b/frontend/templates/notification/purchase_notgot_gift/full.txt
@@ -14,7 +14,7 @@ You can send the link yourself to make sure that it gets to the right place.
 You can also "regift" the ebook to a different email address. To do so, FIRST log in to the {{ gift.giver }} account on Unglue.it, and then click on 
 https://{{ current_site.domain }}{% url 'receive_gift' gift.acq.nonce %}
 
-If you have any problems or questions, don't hesitate to contact Unglue.it support at support@gluejar.com
+If you have any problems or questions, don't hesitate to contact Unglue.it support at support@ebookfoundation.org
 
 the Unglue.it team
 

--- a/frontend/templates/notification/rights_holder_claim/full.txt
+++ b/frontend/templates/notification/rights_holder_claim/full.txt
@@ -3,7 +3,7 @@
 
 You are now free to start a campaign to sell or unglue your work.  If you're logged in, you will see the option to open a campaign at https://{{ current_site.domain }}/rightsholders .  (You can also find this page by clicking on "Rights Holder Tools" at the bottom of any Unglue.it page.)
 
-To run a campaign, you'll need to set up campaign parameters.  You'll also need to write a pitch.  For Pledge-to-Unglue and Buy-to-Unglue campaigns, this will appear in the Description tab on your book's page (https://{{ current_site.domain }}{% url 'work' claim.work.id %}).  Think about who your book's audience is, and remind them why they'll love this book -- your pitch is not a catalog page!  We encourage video, audio, and links to make your pitch come alive.  For Thanks-for-Ungluing, your pitch will occur when the user clicks a Download button. You should emphasize how the ungluer's support enables you to keep doing what you do. Feel free to email us (rights@gluejar.com) if you need any help with this.
+To run a campaign, you'll need to set up campaign parameters.  You'll also need to write a pitch.  For Pledge-to-Unglue and Buy-to-Unglue campaigns, this will appear in the Description tab on your book's page (https://{{ current_site.domain }}{% url 'work' claim.work.id %}).  Think about who your book's audience is, and remind them why they'll love this book -- your pitch is not a catalog page!  We encourage video, audio, and links to make your pitch come alive.  For Thanks-for-Ungluing, your pitch will occur when the user clicks a Download button. You should emphasize how the ungluer's support enables you to keep doing what you do. Feel free to email us (rights@ebookfoundation.org) if you need any help with this.
 
 If you're running a Buy-to-Unglue or Thanks-for-Ungluing Campaign, now is the time to upload your digital files. For Buy-to-Unglue, you need to decide on revenue targets and pricing for individual and library licenses.
 
@@ -17,7 +17,7 @@ We're thrilled to be working with you.
 {{ claim.rights_holder }}'s claim to {{ claim.work.title }} (https://{{ current_site.domain }}{% url 'work' claim.work.id %}) on Unglue.it has been entered. Our team will examine the claim and get back to you soon.
 {% endifequal %}
 {% ifequal claim.status 'release' %}
-{{ claim.rights_holder }}'s claim to {{ claim.work.title }} (https://{{ current_site.domain }}{% url 'work' claim.work.id %}) on Unglue.it has been released. email us (rights@gluejar.com) if you have any questions about this.
+{{ claim.rights_holder }}'s claim to {{ claim.work.title }} (https://{{ current_site.domain }}{% url 'work' claim.work.id %}) on Unglue.it has been released. email us (rights@ebookfoundation.org) if you have any questions about this.
 {% endifequal %}
 
 The Unglue.it team

--- a/frontend/templates/notification/rights_holder_claim/notice.html
+++ b/frontend/templates/notification/rights_holder_claim/notice.html
@@ -17,7 +17,7 @@
 <br /><br />
 You are now free to start a campaign to sell or unglue your work.  If you're logged in, you can <a href="{% url 'rightsholders' %}">open a campaign</a>.  (You can also find this page by clicking on "Rights Holder Tools" at the bottom of any Unglue.it page.)
 <br /><br />
-To run a campaign, you'll need to set up campaign parameters.  You'll also need to write a pitch.  For Pledge-to-Unglue and Buy-to-Unglue campaigns, this will appear in the Description tab on your book's <a href="{% url 'work' claim.work.id %}">work page</a>.  Think about who your book's audience is, and remind them why they'll love this book -- your pitch is not a catalog page!  We encourage video, audio, and links to make your pitch come alive.  For Thanks-for-Ungluing, your pitch will occur when the user clicks a Download button. You should emphasize how the ungluer's support enables you to keep doing what you do. Feel free to email us (rights@gluejar.com) if you need any help with this.
+To run a campaign, you'll need to set up campaign parameters.  You'll also need to write a pitch.  For Pledge-to-Unglue and Buy-to-Unglue campaigns, this will appear in the Description tab on your book's <a href="{% url 'work' claim.work.id %}">work page</a>.  Think about who your book's audience is, and remind them why they'll love this book -- your pitch is not a catalog page!  We encourage video, audio, and links to make your pitch come alive.  For Thanks-for-Ungluing, your pitch will occur when the user clicks a Download button. You should emphasize how the ungluer's support enables you to keep doing what you do. Feel free to email us (rights@ebookfoundation.org) if you need any help with this.
 <br /><br />
 If you're running a Buy-to-Unglue or Thanks-for-Ungluing Campaign, now is the time to upload your digital files. For Buy-to-Unglue, you need to decide on revenue targets and pricing for individual and library licenses.
 <br /><br />
@@ -31,6 +31,6 @@ We're thrilled to be working with you.
 	The claim for <a href="{% url 'work' claim.work.id %}">{{ claim.work.title }}</a> will be examined, and we'll email you.  <a href="{% url 'feedback' %}?page={{request.build_absolute_uri|urlencode:""}}">Contact us</a> if you need any help.
 	{% endifequal %}
 	{% ifequal claim.status 'release' %}
-	The claim for <a href="{% url 'work' claim.work.id %}">{{ claim.work.title }}</a> has been released.  Contact us at rights@gluejar.com if you have questions.
+	The claim for <a href="{% url 'work' claim.work.id %}">{{ claim.work.title }}</a> has been released.  Contact us at rights@ebookfoundation.org if you have questions.
 	{% endifequal %}
 {% endblock %}

--- a/frontend/templates/notification/rights_holder_created/full.txt
+++ b/frontend/templates/notification/rights_holder_created/full.txt
@@ -6,6 +6,6 @@ If your book isn't listed in Google Books (which powers our search), you won't b
 
 You can also start thinking ahead about what you'd like your campaigns to look like and how you'd like to publicize them.  Some good things to brainstorm: your campaign pitch; any photos or video you can include; compelling premiums you might be able to offer; what you want your target to be and how long you think your campaign should last; and how to share your campaign with your social networks (online and off) and media contacts.
 
-Need help with any of this?  We'd be delighted.  Email us at rights@gluejar.com.  We're thrilled to be working with you.
+Need help with any of this?  We'd be delighted.  Email us at rights@ebookfoundation.org.  We're thrilled to be working with you.
 
 The Unglue.it team

--- a/frontend/templates/notification/wishlist_unglued_book_released/full.txt
+++ b/frontend/templates/notification/wishlist_unglued_book_released/full.txt
@@ -24,9 +24,9 @@ The Creative Commons licensing terms for {{ work.title }} allow you to redistrib
 {% endif %}
 
 {% if work.last_campaign_status == 'SUCCESSFUL' %}
-If you have any problems with this unglued ebook, please don't hesitate to let us know at support@gluejar.com. And if you love being able to give this ebook for free to all of your friends, please consider supporting other ebooks for ungluing.
+If you have any problems with this unglued ebook, please don't hesitate to let us know at support@ebookfoundation.org. And if you love being able to give this ebook for free to all of your friends, please consider supporting other ebooks for ungluing.
 {% else %}
-If you have any problems with these ebook files, please don't hesitate to let us know at support@gluejar.com. For example, if the file isn't what it says it is, or if the licensing or copyright status is misrepresented, we want to know as soon as possble.
+If you have any problems with these ebook files, please don't hesitate to let us know at support@ebookfoundation.org. For example, if the file isn't what it says it is, or if the licensing or copyright status is misrepresented, we want to know as soon as possble.
 {% endif %}
 
 Thanks,

--- a/frontend/templates/press_new.html
+++ b/frontend/templates/press_new.html
@@ -21,7 +21,7 @@
 		<a href="#releases">Press Releases</a><br />
 	</div>
 	<div class="pressemail">
-		Additional press questions?  Please email <a href="mailto:press@gluejar.com">press@gluejar.com</a>.
+		Additional press questions?  Please email <a href="mailto:info@ebookfoundation.org">info@ebookfoundation.org</a>.
 	</div>
 	<div class="spacer"></div>
 	{% if request.user.is_staff %}
@@ -58,7 +58,7 @@ When books have a clear, established legal license which promotes use, they can 
 <dt>When?</dt>
 <dd>Unglue.it launched its first crowdfunding campaign on May 17, 2012. Buy-to-Unglue launched in January of 2014, and Thanks-for-Ungluing launched in April of 2014.</dd>
 <dt>Where?</dt>
-<dd>The Free Ebook Foundation is a New Jersey non-for-profit corporation, but its employees and contractors live and work across North America.  The best way to contact us is by email, <a href="mailto:press@gluejar.com">freeebookfoundation@gmail.com</a>.</dd>
+<dd>The Free Ebook Foundation is a New Jersey non-for-profit corporation, but its employees and contractors live and work across North America.  The best way to contact us is by email, <a href="mailto:info@ebookfoundation.org">info@ebookfoundation.org</a>.</dd>
 <dt>What's your technology?</dt>
 <dd>Unglue.it is built using <a href="http://python.org/">Python</a> and the <a href="https://www.djangoproject.com/">Django framework</a>.  We use data from the <a href="http://code.google.com/apis/books/docs/v1/getting_started.html">Google Books</a>, <a href="http://openlibrary.org/developers/api">Open Library</a>, <a href="http://www.librarything.com/api">LibraryThing</a>, and <a href="http://www.goodreads.com/api">GoodReads</a> APIs; we appreciate that they've made these APIs available, and we're returning the favor with <a href="/api/help">our own API</a>.  You're welcome to use it.  We use <a href="http://lesscss.org/">Less</a> to organize our CSS.  We process pledges with <a href="https://stripe.com/">Stripe</a>.  We collaborate on our code at <a href="https://github.com/">GitHub</a> and deploy to the cloud with <a href="http://aws.amazon.com/ec2/">Amazon EC2</a>.</dd>
 <dt>What licenses are supported?  </dt>
@@ -68,7 +68,7 @@ We support a additional Free Licenses in our Thanks-for-Ungluing program.
 </dd>
 
 <dt>I have more questions...</dt>
-<dd>Please consult our <a href="/faq/">FAQ</a> (sidebar at left); join the site and explore its features for yourself; or email us, <a href="press@gluejar.com">press@gluejar.com</a>.</dd>
+<dd>Please consult our <a href="/faq/">FAQ</a> (sidebar at left); join the site and explore its features for yourself; or email us, <a href="infor@ebookfoundation.org">info@ebookfoundation.org</a>.</dd>
 </dl>
 <a id="press"></a><h2>Media Highlights</h2>
 <div class="pressarticles">

--- a/frontend/templates/registration/registration_complete.html
+++ b/frontend/templates/registration/registration_complete.html
@@ -6,7 +6,7 @@
 {% if not user.is_authenticated %}
 
 <p>
-An account activation email has been sent.  Please check your email and click on the link to activate your account. We're also sending you an invitation to our email newsletter. It comes out about twice a month. Put "gluenews@gluejar.com" in your contact list to make sure you get it.
+An account activation email has been sent.  Please check your email and click on the link to activate your account. We're also sending you an invitation to our email newsletter. It comes out about twice a month. Put "unglueit@ebookfoundation.org" in your contact list to make sure you get it.
 </p>
     {% if request.COOKIES.next %}
 

--- a/frontend/templates/rh_tools.html
+++ b/frontend/templates/rh_tools.html
@@ -18,7 +18,7 @@
 <h1>unglue.it Tools for Rightsholders</h1>
 
 <div class="presstoc"><div class="pressemail">
-Any questions not covered here?  Please email us at <a href="mailto:rights@gluejar.com">rights@gluejar.com</a>.
+Any questions not covered here?  Please email us at <a href="mailto:rights@ebookfoundation.org">rights@ebookfoundation.org</a>.
 </div></div>
 <h2>Contents</h2>
 <ul class="bullets">
@@ -223,7 +223,7 @@ If you're an author, publisher, or other rights holder, you can participate more
     {% else %}
     <li class="checked">You've already set up an Unglue.it account.</li>
     {% endif %}
-	{% if not request.user.rights_holder.count %}<li>{% else %}<li class="checked">{% endif %}Sign a <a href="https://www.docracy.com/1mud3ve9w8/unglue-it-non-exclusive-platform-services-agreement">Platform Services Agreement</a>. Unglue.it uses Docracy.com to manage rights holder agreements. If you have any questions, <a href="mailto:rights@gluejar.com?subject=agreement">ask us</a>.</li>
+	{% if not request.user.rights_holder.count %}<li>{% else %}<li class="checked">{% endif %}Sign a <a href="https://www.docracy.com/1mud3ve9w8/unglue-it-non-exclusive-platform-services-agreement">Platform Services Agreement</a>. Unglue.it uses Docracy.com to manage rights holder agreements. If you have any questions, <a href="mailto:rights@ebookfoundation.org?subject=agreement">ask us</a>.</li>
 	{% if claims %}
 	<li class="checked"><i>You have claimed {{ claims.count }}</i> work(s). You can claim more.
 	{% else %}
@@ -240,7 +240,7 @@ If you're an author, publisher, or other rights holder, you can participate more
 	<ul class="bullets">
 	    <li>Use the Claim option on the More... tab of each book's page.</li>
 	    <li>Agree to our <a href="{% url 'terms' %}">Terms</a> on the following page.  This includes agreeing that you are making the claim in good faith and can substantiate that you have legal control over worldwide electronic rights to the work.</li>
-	    <li>If you have any questions or you claim a work by mistake, <a href="mailto:rights@gluejar.com?subject=claiming%20works">email us</a>.</li>
+	    <li>If you have any questions or you claim a work by mistake, <a href="mailto:rights@ebookfoundation.org?subject=claiming%20works">email us</a>.</li>
 	    <li>We will review your claim.  We may contact you at {{ request.user.email }} if we have any questions.  If this is the wrong email address, please <a href="{% url 'edit_user' %}">change the email address</a> for your account.</li>
 	</ul>
 	<p><b>Entering a work</b></p>

--- a/frontend/templates/terms.html
+++ b/frontend/templates/terms.html
@@ -256,7 +256,7 @@ The Free Ebook Foundation.<br />
 41 Watchung Plaza, #132<br />
 Montclair, NJ 07042<br />
 USA<br />
-dmca@gluejar.com<br />
+info@ebookfoundation.org<br />
 
 
 <a id="notice"><h3>Electronic Delivery/Notice Policy and Your Consent</h3></a>

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -2824,7 +2824,7 @@ def ask_rh(request, campaign_id):
             redirect_url = reverse('work', args=[campaign.work.id]),
             extra_context={'campaign':campaign, 'subject':campaign })
 
-def feedback(request, recipient='support@gluejar.com', template='feedback.html', message_template='feedback.txt', extra_context=None, redirect_url=None):
+def feedback(request, recipient='support@ebookfoundation.org', template='feedback.html', message_template='feedback.txt', extra_context=None, redirect_url=None):
     context = extra_context or {}
     context['num1'] = randint(0, 10)
     context['num2'] = randint(0, 10)

--- a/settings/common.py
+++ b/settings/common.py
@@ -236,7 +236,7 @@ LOGGING = {
 EMAIL_HOST = 'smtp.gluejar.com'
 DEFAULT_FROM_EMAIL = 'notices@gluejar.com'
 SERVER_EMAIL = 'notices@gluejar.com'
-SUPPORT_EMAIL = 'support@gluejar.com'
+SUPPORT_EMAIL = 'support@ebookfoundation.org'
 ACCOUNT_ACTIVATION_DAYS = 30
 SESSION_COOKIE_AGE = 3628800 # 6 weeks
 

--- a/sysadmin/csr_temp_cert_for_host.sh
+++ b/sysadmin/csr_temp_cert_for_host.sh
@@ -36,7 +36,7 @@ LOCALITY="Montclair";
 ORGNAME="Gluejar, Inc.";
 ORGUNIT="";
 CNAME=$HOSTNAME;
-EMAIL="eric@gluejar.com";
+EMAIL="eric@ebookfoundation.org";
 PASSWORD="";
 OPTION_COMPANY_NAME="";
 

--- a/sysadmin/gen_csr.sh
+++ b/sysadmin/gen_csr.sh
@@ -17,7 +17,7 @@ LOCALITY="Montclair";
 ORGNAME="Gluejar, Inc.";
 ORGUNIT="";
 CNAME="*.unglue.it";
-EMAIL="support@gluejar.com";
+EMAIL="support@ebookfoundation.org";
 PASSWORD="";
 OPTION_COMPANY_NAME="";
 


### PR DESCRIPTION
(except for notices@gluejar.com, which is what gets set in kindle
whitelists)